### PR TITLE
fix: pass language param to Whisper API for correct English transcrip…

### DIFF
--- a/src/lib/openai.service.ts
+++ b/src/lib/openai.service.ts
@@ -173,7 +173,8 @@ export async function transcribeAudio(
   audioFile: File,
   userId: string,
   supabaseClient: SupabaseClient<Database>,
-  audioDurationSeconds?: number
+  audioDurationSeconds?: number,
+  language?: string
 ): Promise<{
   transcript?: string;
   error?: string;
@@ -222,7 +223,7 @@ export async function transcribeAudio(
     const formData = new FormData();
     formData.append("file", audioFile);
     formData.append("model", "whisper-1");
-    formData.append("language", "pl");
+    formData.append("language", language || "pl");
 
     const response = await fetch(`${OPENAI_API_BASE_URL}/audio/transcriptions`, {
       method: "POST",

--- a/src/pages/api/learn/transcribe.ts
+++ b/src/pages/api/learn/transcribe.ts
@@ -58,6 +58,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     // 4. Pobranie danych formularza
     const formData = await request.formData();
     const audioFile = formData.get("audio") as File | null;
+    const language = (formData.get("language") as string) || undefined;
 
     if (!audioFile) {
       return new Response(JSON.stringify({ error: "Nie znaleziono pliku audio" }), {
@@ -134,7 +135,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
       const correctAudioFile = new File([audioData], `recording.${newExtension}`, { type: `audio/${newExtension}` });
 
       // 8. Wywołanie API Whisper przez nasz serwis z poprawionym plikiem
-      const { transcript, error, errorCode } = await transcribeAudio(correctAudioFile, userId, locals.supabase);
+      const { transcript, error, errorCode } = await transcribeAudio(
+        correctAudioFile,
+        userId,
+        locals.supabase,
+        undefined,
+        language
+      );
 
       if (error) {
         let statusCode = 500;
@@ -157,7 +164,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     // 8. Wywołanie API Whisper przez nasz serwis (używając oryginalnego pliku, jeśli jego rozszerzenie jest ok)
-    const { transcript, error, errorCode } = await transcribeAudio(audioFile, userId, locals.supabase);
+    const { transcript, error, errorCode } = await transcribeAudio(
+      audioFile,
+      userId,
+      locals.supabase,
+      undefined,
+      language
+    );
 
     if (error) {
       let statusCode = 500;


### PR DESCRIPTION
…tion

The Whisper API had language hardcoded to "pl", causing English speech to be translated into Polish instead of transcribed verbatim. Now the transcribe endpoint reads the optional language field from form data and passes it through to the OpenAI service, defaulting to "pl" for existing flashcard features while the English module sends "en".

Also fixes Prettier formatting in Astro english pages.