### PR TITLE
feat(session): replace full-screen review with per-question inline hint

### DIFF
--- a/src/components/english/EnglishLessonSession.tsx
+++ b/src/components/english/EnglishLessonSession.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import type {
   CEFRLevel,
   EnglishDialogue,
+  IntroDemoTurn,
   LessonPhase,
   EvaluationResult,
   DialogueTurn,
@@ -90,6 +91,23 @@ function advanceToNextTurn(prev: SessionState): SessionState {
   return { ...prev, phase: "summary" };
 }
 
+/** Normalize curly/typographic apostrophes and quotes to ASCII equivalents for comparison */
+function normalizeApostrophes(s: string): string {
+  return s.replace(/[\u2018\u2019\u201a\u201b\u2032]/g, "'").replace(/[\u201c\u201d\u201e\u201f\u2033]/g, '"');
+}
+
+/** Find the demo pair (teacher turn + following peer turn) matching a given teacher question */
+function findDemoPair(demo: IntroDemoTurn[], teacherText: string): IntroDemoTurn[] {
+  const normalized = normalizeApostrophes(teacherText);
+  const idx = demo.findIndex((t) => t.role === "teacher" && normalizeApostrophes(t.text) === normalized);
+  if (idx === -1) return [];
+  const pair: IntroDemoTurn[] = [demo[idx]];
+  if (idx + 1 < demo.length && demo[idx + 1].role === "peer") {
+    pair.push(demo[idx + 1]);
+  }
+  return pair;
+}
+
 // ---------- TYPES ----------
 
 interface EnglishLessonSessionProps {
@@ -113,10 +131,6 @@ interface SessionState {
   isLoading: boolean;
   error: string | null;
   sessionStartTime: number;
-  /** Phase to restore after the child finishes reviewing the intro demo */
-  reviewReturnPhase: LessonPhase | null;
-  /** TeacherSubPhase to restore after review */
-  reviewReturnTeacherSubPhase: TeacherSubPhase | null;
 }
 
 interface ConversationEntry {
@@ -128,6 +142,8 @@ interface ConversationEntry {
   /** Optional explicit image URL override */
   imageUrl?: string;
   evaluationResult?: EvaluationResult;
+  /** Matching demo pair (teacher + peer) for this teacher turn — enables inline hint */
+  demoPair?: IntroDemoTurn[];
 }
 
 /**
@@ -148,15 +164,10 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
     isLoading: true,
     error: null,
     sessionStartTime: Date.now(),
-    reviewReturnPhase: null,
-    reviewReturnTeacherSubPhase: null,
   });
 
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const [conversationHistory, setConversationHistory] = useState<ConversationEntry[]>([]);
-  // Once the review intro has been opened once, keep IntroDemo mounted in the background
-  // so the audio cache and scroll position survive between repeated visits.
-  const [reviewIntroEverOpened, setReviewIntroEverOpened] = useState(false);
 
   // ---------- DATA LOADING ----------
 
@@ -201,6 +212,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
         if (!hasIntro) {
           const firstTurn = firstDialogue?.turns[0];
           if (firstTurn && firstTurn.role === "teacher") {
+            const demo = firstDialogue.intro?.demo;
             setConversationHistory([
               {
                 type: "teacher",
@@ -208,6 +220,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
                 hint: firstTurn.hint,
                 dialogueId: firstDialogue.id,
                 imageUrl: firstDialogue.image_url,
+                demoPair: demo ? findDemoPair(demo, firstTurn.text) : undefined,
               },
             ]);
           }
@@ -374,6 +387,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
       if (dialogue && next.phase === "teacher_speaking") {
         const turn = dialogue.turns[next.currentTurnIndex];
         if (turn && isTeacherTurn(turn)) {
+          const demo = dialogue.intro?.demo;
           setConversationHistory((h) => [
             ...h,
             {
@@ -382,6 +396,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
               hint: turn.hint,
               dialogueId: dialogue.id,
               imageUrl: dialogue.image_url,
+              demoPair: demo ? findDemoPair(demo, turn.text) : undefined,
             },
           ]);
         }
@@ -395,6 +410,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
   const addFirstTeacherTurnToHistory = useCallback((dialogue: EnglishDialogue) => {
     const firstTurn = dialogue.turns[0];
     if (firstTurn && isTeacherTurn(firstTurn)) {
+      const demo = dialogue.intro?.demo;
       setConversationHistory((h) => [
         ...h,
         {
@@ -403,6 +419,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
           hint: firstTurn.hint,
           dialogueId: dialogue.id,
           imageUrl: dialogue.image_url,
+          demoPair: demo ? findDemoPair(demo, firstTurn.text) : undefined,
         },
       ]);
     }
@@ -434,35 +451,6 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
     });
   }, [addFirstTeacherTurnToHistory]);
 
-  /** Open the intro demo as a mid-exercise review — saves current phase to restore later */
-  const handleOpenReviewIntro = useCallback(() => {
-    setReviewIntroEverOpened(true);
-    setState((prev) => {
-      const dialogue = prev.dialogues[prev.currentDialogueIndex];
-      if (!dialogue?.intro?.demo?.length) return prev;
-      return {
-        ...prev,
-        phase: "review_intro",
-        reviewReturnPhase: prev.phase,
-        reviewReturnTeacherSubPhase: prev.teacherSubPhase,
-      };
-    });
-  }, []);
-
-  /** Return to the exact turn the child was on after finishing the review demo */
-  const handleReviewIntroDone = useCallback(() => {
-    setState((prev) => {
-      if (prev.phase !== "review_intro") return prev;
-      return {
-        ...prev,
-        phase: prev.reviewReturnPhase ?? "teacher_speaking",
-        teacherSubPhase: prev.reviewReturnTeacherSubPhase ?? "question",
-        reviewReturnPhase: null,
-        reviewReturnTeacherSubPhase: null,
-      };
-    });
-  }, []);
-
   const handleRetry = useCallback(() => {
     setConversationHistory([]);
     setState((prev) => {
@@ -474,6 +462,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
       if (!hasIntro) {
         const firstTurn = firstDialogue.turns[0];
         if (firstTurn && isTeacherTurn(firstTurn)) {
+          const demo = firstDialogue.intro?.demo;
           setConversationHistory([
             {
               type: "teacher",
@@ -481,6 +470,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
               hint: firstTurn.hint,
               dialogueId: firstDialogue.id,
               imageUrl: firstDialogue.image_url,
+              demoPair: demo ? findDemoPair(demo, firstTurn.text) : undefined,
             },
           ]);
         }
@@ -583,23 +573,6 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
         </div>
 
         <div className="flex items-center gap-3 justify-end">
-          {/* Review intro button — visible when current dialogue has a demo and we're in the exercise */}
-          {currentDialogue?.intro?.demo?.length &&
-            state.phase !== "intro_narrator" &&
-            state.phase !== "intro_demo" &&
-            state.phase !== "review_intro" &&
-            state.phase !== "summary" && (
-              <button
-                type="button"
-                onClick={handleOpenReviewIntro}
-                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-indigo-50 text-indigo-600
-                  hover:bg-indigo-100 transition-colors text-xs font-medium border border-indigo-100"
-                title="Wróć do przykładowej rozmowy"
-              >
-                <span>🎬</span>
-                <span>Przypomnij</span>
-              </button>
-            )}
           <div className="text-right">
             <div className="text-sm font-medium text-gray-700">
               {state.sessionScore.correct}/{state.sessionScore.total}
@@ -637,21 +610,8 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
           <IntroDemo demo={currentDialogue.intro.demo} onFinish={handleIntroDemoComplete} />
         )}
 
-        {/* Mid-exercise review: child revisits the demo already in "done" state */}
-        {/* Mid-exercise review — mounted on first open, then kept alive in background.
-            CSS hidden preserves audio cache and scroll position between visits. */}
-        {reviewIntroEverOpened && currentDialogue?.intro?.demo && (
-          <div className={state.phase === "review_intro" ? "flex flex-col" : "hidden"}>
-            <div className="flex items-center justify-center gap-2 pt-4 pb-1 text-xs text-indigo-500 font-medium">
-              <span>↩</span>
-              <span>Po przypomnieniu wrócisz do tego samego miejsca w ćwiczeniu</span>
-            </div>
-            <IntroDemo demo={currentDialogue.intro.demo} onFinish={handleReviewIntroDone} initiallyDone={true} />
-          </div>
-        )}
-
-        {/* Regular conversation history (hidden during intro / review phases) */}
-        {state.phase !== "intro_narrator" && state.phase !== "intro_demo" && state.phase !== "review_intro" && (
+        {/* Conversation history */}
+        {state.phase !== "intro_narrator" && state.phase !== "intro_demo" && (
           <div className="py-4 space-y-2">
             {conversationHistory.map((entry, idx) => {
               if (entry.type === "teacher") {
@@ -669,6 +629,7 @@ const EnglishLessonSession: React.FC<EnglishLessonSessionProps> = ({ level, stag
                     subPhase={isActive ? state.teacherSubPhase : "question"}
                     onAudioComplete={handleTeacherAudioComplete}
                     isActive={isActive}
+                    demoPair={entry.demoPair}
                   />
                 );
               }

--- a/src/components/english/IntroDemo.tsx
+++ b/src/components/english/IntroDemo.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
 import AudioPlayer from "./AudioPlayer";
+import ReplayButton from "./ReplayButton";
 import type { IntroDemoTurn } from "../../types/english";
 
 interface IntroDemoProps {
   demo: IntroDemoTurn[];
-  /** Called when user clicks "Zaczynamy!" after all turns are shown */
+  /** Called when user clicks the finish button after all turns are shown */
   onFinish: () => void;
   /**
    * When true the component skips sequential auto-play and opens directly
@@ -12,6 +13,8 @@ interface IntroDemoProps {
    * Used when the child revisits the demo mid-exercise.
    */
   initiallyDone?: boolean;
+  /** Label for the finish button. Defaults to "Zaczynamy! 🚀" */
+  finishLabel?: string;
 }
 
 async function fetchTeacherAudio(text: string): Promise<string | undefined> {
@@ -44,76 +47,6 @@ async function fetchNarratorAudio(text: string): Promise<string | undefined> {
   }
 }
 
-// ── Small standalone replay button ──────────────────────────────────────────
-
-interface ReplayButtonProps {
-  text: string;
-  lang: string;
-  audioSrc: string | null | undefined;
-  label?: string;
-}
-
-function ReplayButton({ text, lang, audioSrc, label }: ReplayButtonProps) {
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const speakTTS = useCallback((t: string, l: string) => {
-    if (!("speechSynthesis" in window)) return;
-    window.speechSynthesis.cancel();
-    const utt = new SpeechSynthesisUtterance(t);
-    utt.lang = l;
-    utt.rate = 0.9;
-    setIsPlaying(true);
-    utt.onend = () => setIsPlaying(false);
-    utt.onerror = () => setIsPlaying(false);
-    window.speechSynthesis.speak(utt);
-  }, []);
-
-  const play = useCallback(() => {
-    if (isPlaying) return;
-    const src = audioSrc ?? undefined;
-    if (src) {
-      const audio = new Audio(src);
-      setIsPlaying(true);
-      audio.onended = () => setIsPlaying(false);
-      audio.onerror = () => {
-        setIsPlaying(false);
-        if (text) speakTTS(text, lang);
-      };
-      audio.play().catch(() => {
-        setIsPlaying(false);
-        if (text) speakTTS(text, lang);
-      });
-    } else if (text) {
-      speakTTS(text, lang);
-    }
-  }, [isPlaying, audioSrc, text, lang, speakTTS]);
-
-  return (
-    <button
-      type="button"
-      onClick={play}
-      disabled={isPlaying}
-      className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-all ${
-        isPlaying
-          ? "bg-blue-100 text-blue-600 animate-pulse cursor-default"
-          : "bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
-      }`}
-      title="Odsłuchaj ponownie"
-    >
-      {isPlaying ? (
-        <svg className="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
-        </svg>
-      ) : (
-        <svg className="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M8 5v14l11-7z" />
-        </svg>
-      )}
-      {label && <span>{label}</span>}
-    </button>
-  );
-}
-
 // ── Main component ────────────────────────────────────────────────────────────
 
 /**
@@ -122,7 +55,7 @@ function ReplayButton({ text, lang, audioSrc, label }: ReplayButtonProps) {
  * Completed turns show replay buttons so the child can listen again.
  * After all turns finish, a "Zaczynamy!" button appears.
  */
-const IntroDemo: React.FC<IntroDemoProps> = ({ demo, onFinish, initiallyDone = false }) => {
+const IntroDemo: React.FC<IntroDemoProps> = ({ demo, onFinish, initiallyDone = false, finishLabel }) => {
   const [visibleCount, setVisibleCount] = useState(initiallyDone ? demo.length : 0);
   // How many turns have their PL translation text revealed
   const [plRevealedCount, setPlRevealedCount] = useState(initiallyDone ? demo.length : 0);
@@ -379,7 +312,7 @@ const IntroDemo: React.FC<IntroDemoProps> = ({ demo, onFinish, initiallyDone = f
               hover:bg-green-700 active:bg-green-800 transition-colors shadow-md
               animate-[fadeIn_0.4s_ease-in]"
           >
-            Zaczynamy! 🚀
+            {finishLabel ?? "Zaczynamy! 🚀"}
           </button>
         </div>
       )}

--- a/src/components/english/IntroDemo.tsx
+++ b/src/components/english/IntroDemo.tsx
@@ -95,8 +95,7 @@ const IntroDemo: React.FC<IntroDemoProps> = ({ demo, onFinish, initiallyDone = f
         });
       }
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initiallyDone]);
+  }, [initiallyDone, demo]);
 
   // Fetch EN audio when a new turn becomes visible
   useEffect(() => {

--- a/src/components/english/ReplayButton.tsx
+++ b/src/components/english/ReplayButton.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useCallback } from "react";
+
+interface ReplayButtonProps {
+  text: string;
+  lang: string;
+  audioSrc: string | null | undefined;
+  label?: string;
+}
+
+const ReplayButton: React.FC<ReplayButtonProps> = ({ text, lang, audioSrc, label }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const speakTTS = useCallback(
+    (t: string, l: string) => {
+      if (!("speechSynthesis" in window)) return;
+      window.speechSynthesis.cancel();
+      const utt = new SpeechSynthesisUtterance(t);
+      utt.lang = l;
+      utt.rate = 0.9;
+      setIsPlaying(true);
+      utt.onend = () => setIsPlaying(false);
+      utt.onerror = () => setIsPlaying(false);
+      window.speechSynthesis.speak(utt);
+    },
+    []
+  );
+
+  const play = useCallback(() => {
+    if (isPlaying) return;
+    const src = audioSrc ?? undefined;
+    if (src) {
+      const audio = new Audio(src);
+      setIsPlaying(true);
+      audio.onended = () => setIsPlaying(false);
+      audio.onerror = () => {
+        setIsPlaying(false);
+        if (text) speakTTS(text, lang);
+      };
+      audio.play().catch(() => {
+        setIsPlaying(false);
+        if (text) speakTTS(text, lang);
+      });
+    } else if (text) {
+      speakTTS(text, lang);
+    }
+  }, [isPlaying, audioSrc, text, lang, speakTTS]);
+
+  return (
+    <button
+      type="button"
+      onClick={play}
+      disabled={isPlaying}
+      className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-all ${
+        isPlaying
+          ? "bg-blue-100 text-blue-600 animate-pulse cursor-default"
+          : "bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+      }`}
+      title="Odsłuchaj ponownie"
+    >
+      {isPlaying ? (
+        <svg className="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
+        </svg>
+      ) : (
+        <svg className="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      )}
+      {label && <span>{label}</span>}
+    </button>
+  );
+};
+
+export default ReplayButton;

--- a/src/components/english/ReplayButton.tsx
+++ b/src/components/english/ReplayButton.tsx
@@ -10,20 +10,17 @@ interface ReplayButtonProps {
 const ReplayButton: React.FC<ReplayButtonProps> = ({ text, lang, audioSrc, label }) => {
   const [isPlaying, setIsPlaying] = useState(false);
 
-  const speakTTS = useCallback(
-    (t: string, l: string) => {
-      if (!("speechSynthesis" in window)) return;
-      window.speechSynthesis.cancel();
-      const utt = new SpeechSynthesisUtterance(t);
-      utt.lang = l;
-      utt.rate = 0.9;
-      setIsPlaying(true);
-      utt.onend = () => setIsPlaying(false);
-      utt.onerror = () => setIsPlaying(false);
-      window.speechSynthesis.speak(utt);
-    },
-    []
-  );
+  const speakTTS = useCallback((t: string, l: string) => {
+    if (!("speechSynthesis" in window)) return;
+    window.speechSynthesis.cancel();
+    const utt = new SpeechSynthesisUtterance(t);
+    utt.lang = l;
+    utt.rate = 0.9;
+    setIsPlaying(true);
+    utt.onend = () => setIsPlaying(false);
+    utt.onerror = () => setIsPlaying(false);
+    window.speechSynthesis.speak(utt);
+  }, []);
 
   const play = useCallback(() => {
     if (isPlaying) return;

--- a/src/components/english/TeacherBubble.tsx
+++ b/src/components/english/TeacherBubble.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import AudioPlayer from "./AudioPlayer";
+import ReplayButton from "./ReplayButton";
+import type { IntroDemoTurn } from "../../types/english";
 
 interface TeacherBubbleProps {
   /** Teacher's question/statement text */
@@ -22,6 +24,11 @@ interface TeacherBubbleProps {
   onAudioComplete: () => void;
   /** Whether this is an active (current) bubble */
   isActive: boolean;
+  /**
+   * Matching demo pair (teacher + peer turns) for this question.
+   * When provided, a "Przypomnij" toggle appears below the question.
+   */
+  demoPair?: IntroDemoTurn[];
 }
 
 /** Resolve image source: explicit URL takes priority, then local asset by dialogue ID */
@@ -46,10 +53,98 @@ async function fetchTeacherAudio(text: string): Promise<string | undefined> {
   }
 }
 
+async function fetchNarratorAudio(text: string): Promise<string | undefined> {
+  try {
+    const res = await fetch("/api/english/narrator-audio", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) return undefined;
+    const data = await res.json();
+    return data.audio_url as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Inline demo pair hint ──────────────────────────────────────────────────────
+
+interface DemoPairHintProps {
+  pair: IntroDemoTurn[];
+}
+
+const DemoPairHint: React.FC<DemoPairHintProps> = ({ pair }) => {
+  const [enAudioCache, setEnAudioCache] = useState<Record<number, string | null>>({});
+  const [plAudioCache, setPlAudioCache] = useState<Record<number, string | null>>({});
+
+  // Fetch all audio on first mount
+  useEffect(() => {
+    pair.forEach((turn, idx) => {
+      if (!turn.audio_url) {
+        fetchTeacherAudio(turn.text).then((url) => {
+          setEnAudioCache((prev) => ({ ...prev, [idx]: url ?? null }));
+        });
+      }
+      if (turn.translation_pl && !turn.translation_audio_url) {
+        fetchNarratorAudio(turn.translation_pl).then((url) => {
+          setPlAudioCache((prev) => ({ ...prev, [idx]: url ?? null }));
+        });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="mt-2 rounded-xl border border-indigo-100 bg-white/80 px-3 py-2.5 space-y-2.5">
+      {pair.map((turn, idx) => {
+        const isTeacher = turn.role === "teacher";
+        const enSrc = turn.audio_url ?? enAudioCache[idx] ?? undefined;
+        const plSrc = turn.translation_audio_url ?? plAudioCache[idx] ?? undefined;
+
+        return (
+          <div key={idx} className={`flex items-start gap-2 ${isTeacher ? "" : "flex-row-reverse"}`}>
+            <span className="text-sm flex-shrink-0 mt-0.5">{isTeacher ? "🎓" : "👦"}</span>
+            <div className={`flex flex-col gap-1 ${isTeacher ? "items-start" : "items-end"}`}>
+              {/* EN bubble */}
+              <div
+                className={`rounded-xl px-3 py-1.5 text-sm ${
+                  isTeacher
+                    ? "bg-indigo-100 text-indigo-900 rounded-bl-sm"
+                    : "bg-green-100 text-green-900 rounded-br-sm"
+                }`}
+              >
+                <p className="leading-snug">{turn.text}</p>
+                <div className={`mt-1 flex ${isTeacher ? "justify-start" : "justify-end"}`}>
+                  <ReplayButton text={turn.text} lang="en-US" audioSrc={enSrc} label="EN" />
+                </div>
+              </div>
+
+              {/* PL translation */}
+              {turn.translation_pl && (
+                <div className="rounded-xl px-3 py-1 text-xs bg-amber-50 border border-amber-100 text-amber-800">
+                  <p className="italic leading-snug">{turn.translation_pl}</p>
+                  <div className={`mt-1 flex ${isTeacher ? "justify-start" : "justify-end"}`}>
+                    <ReplayButton text={turn.translation_pl} lang="pl-PL" audioSrc={plSrc} label="PL" />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 /**
  * Displays a teacher speech bubble with text, optional image, and audio playback.
  * Handles sequential playback: question → repeat → hint.
  * When no pre-generated audio is provided, fetches ElevenLabs EN TTS on demand.
+ * When `demoPair` is provided, shows a "Przypomnij" toggle to reveal the matching
+ * example exchange inline below the question.
  */
 const TeacherBubble: React.FC<TeacherBubbleProps> = ({
   text,
@@ -60,6 +155,7 @@ const TeacherBubble: React.FC<TeacherBubbleProps> = ({
   subPhase,
   onAudioComplete,
   isActive,
+  demoPair,
 }) => {
   const showHint = subPhase === "hint" && hint;
   const [imageError, setImageError] = useState(false);
@@ -67,6 +163,10 @@ const TeacherBubble: React.FC<TeacherBubbleProps> = ({
   // ElevenLabs audio fetched on demand when no pre-generated audio exists
   const [elAudio, setElAudio] = useState<{ text?: string; hint?: string }>({});
   const [audioReady, setAudioReady] = useState(false);
+
+  // Demo pair toggle — once opened, keep DemoPairHint mounted to preserve audio cache
+  const [showDemoHint, setShowDemoHint] = useState(false);
+  const [demoHintEverOpened, setDemoHintEverOpened] = useState(false);
 
   useEffect(() => {
     if (!isActive) return;
@@ -105,8 +205,13 @@ const TeacherBubble: React.FC<TeacherBubbleProps> = ({
 
   const imageSrc = resolveImageSrc(dialogueId, imageUrl);
 
+  const handleToggleDemoHint = () => {
+    if (!demoHintEverOpened) setDemoHintEverOpened(true);
+    setShowDemoHint((prev) => !prev);
+  };
+
   return (
-    <div className={`flex items-start gap-3 mb-4 ${isActive ? "opacity-100" : "opacity-60"}`}>
+    <div className={`flex items-start gap-3 mb-4 ${isActive ? "opacity-100" : "opacity-70"}`}>
       {/* Teacher avatar */}
       <div className="flex-shrink-0 w-10 h-10 bg-indigo-100 rounded-full flex items-center justify-center">
         <span className="text-lg" role="img" aria-label="Nauczyciel">
@@ -133,6 +238,31 @@ const TeacherBubble: React.FC<TeacherBubbleProps> = ({
           <p className="text-gray-800 text-base leading-relaxed">{text}</p>
 
           {showHint && <p className="mt-2 text-indigo-600 text-sm italic border-t border-indigo-100 pt-2">💡 {hint}</p>}
+
+          {/* "Przypomnij" toggle button */}
+          {demoPair && demoPair.length > 0 && (
+            <div className="mt-2.5 pt-2 border-t border-indigo-100">
+              <button
+                type="button"
+                onClick={handleToggleDemoHint}
+                className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors ${
+                  showDemoHint
+                    ? "bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
+                    : "bg-white text-indigo-500 hover:bg-indigo-50 border border-indigo-100"
+                }`}
+              >
+                <span>{showDemoHint ? "✕" : "💡"}</span>
+                <span>{showDemoHint ? "Zamknij" : "Przypomnij"}</span>
+              </button>
+
+              {/* Keep mounted after first open to preserve audio cache */}
+              {demoHintEverOpened && (
+                <div className={showDemoHint ? "" : "hidden"}>
+                  <DemoPairHint pair={demoPair} />
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Audio player — shown after audio is ready */}

--- a/src/components/english/TeacherBubble.tsx
+++ b/src/components/english/TeacherBubble.tsx
@@ -92,8 +92,7 @@ const DemoPairHint: React.FC<DemoPairHintProps> = ({ pair }) => {
         });
       }
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pair]);
 
   return (
     <div className="mt-2 rounded-xl border border-indigo-100 bg-white/80 px-3 py-2.5 space-y-2.5">

--- a/src/types/english.ts
+++ b/src/types/english.ts
@@ -206,7 +206,6 @@ export interface ProgressSummaryResponse {
 export type LessonPhase =
   | "intro_narrator"
   | "intro_demo"
-  | "review_intro" // mid-exercise: child revisits the demo, then returns to same turn
   | "teacher_speaking"
   | "student_turn"
   | "evaluating"


### PR DESCRIPTION
Each TeacherBubble now shows a "Przypomnij" toggle button that reveals the matching demo pair (teacher question + peer answer with EN/PL audio replay) inline below the question image. Removes the review_intro phase entirely. Extracts ReplayButton to a shared component. Adds apostrophe normalization in findDemoPair to handle curly vs straight apostrophe mismatches between exercise turns and demo data.

Made-with: Cursor